### PR TITLE
Fix build status badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Italian Vip Says
 [![codecov](https://codecov.io/gh/Owanesh/italian-vip-says/branch/master/graph/badge.svg)](https://codecov.io/gh/Owanesh/italian-vip-says) 
-[![Build Status](https://travis-ci.org/Owanesh/italian-vip-says.svg?branch=master)](https://travis-ci.org/Owanesh/italian-vip-says) 
+[![Build Status](https://travis-ci.org/lotrekagency/italian-vip-says.svg?branch=master)](https://travis-ci.org/lotrekagency/italian-vip-says)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/Owanesh/italian-vip-says/blob/master/LICENSE)
 
 


### PR DESCRIPTION
Replaced url for travis build status badge